### PR TITLE
Support multiple subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and notify the FluxCD daemons upon changes which will trigger a fluxCD Sync.
 FluxCD events (Commit, Sync and Release events) will also be published to pubsub topic
 for later consumtion of different services.
 
-FluxCD events for Google container regetry updates. (no updates are sent to other topics
+FluxCD events for Google container registry updates. (no updates are sent to other topics
 for this changes)
 
 ## Example use cases that consume pubsub events.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ spec:
         env:
           - name: FLUX_EVENTS_PUBSUB_GOOGLE_PROJECT_GCR
             value: "my gcr project"
+          - name: FLUX_EVENTS_PUBSUB_GOOGLE_PUBSUB_SUBSCRIPTION_GCR
+            value: "gcr-events-<myclustername>"
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: "/secrets/pubsub-credentials"
           - name: FLUX_EVENTS_PUBSUB_GOOGLE_PROJECT

--- a/server/server.go
+++ b/server/server.go
@@ -63,7 +63,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 
-	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, "gcr", "gcr")
+	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, "gcr", fmt.Sprintf("gcr-events-%v", googleProject))
 	if err != nil {
 		log.Errorf("pubsub.NewGCRSubscriber: %v", err)
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ var (
 	listenAddress            = command.Flag("listen-address", "HTTP address").Default(":8080").String()
 	googleProject            = command.Flag("google-project", "Google project").Required().String()
 	googleProjectGcrLocation = command.Flag("google-project-gcr", "Google project were gcr is located").Required().String()
+	pubsubSubscriptionGcr    = command.Flag("google-pubsub-subscription-gcr", "Google pubsub subscription for gcr").Default("gcr").String()
 	pubsubTopicEvents        = command.Flag("google-pubsub-topic", "Google pubsub topic for events").Required().String()
 	pubsubTopicActions       = command.Flag("google-pubsub-topic-actions", "Google pubsub topic for actions").Required().String()
 	pubsubSubscription       = command.Flag("google-pubsub-subscription", "Google pubsub subscription").Required().String()
@@ -63,7 +64,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 
-	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, "gcr", fmt.Sprintf("gcr-events-%v", googleProject))
+	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, "gcr", *pubsubSubscriptionGcr)
 	if err != nil {
 		log.Errorf("pubsub.NewGCRSubscriber: %v", err)
 		return nil, err


### PR DESCRIPTION
adding flag  `--google-pubsub-subscription-gcr` to support the option of passing the gcr subscription name that is preferred 