### PR TITLE
adding option to have a different topic for gcr events

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ spec:
           - name: FLUX_EVENTS_PUBSUB_GOOGLE_PROJECT_GCR
             value: "my gcr project"
           - name: FLUX_EVENTS_PUBSUB_GOOGLE_PUBSUB_SUBSCRIPTION_GCR
-            value: "gcr-events-<myclustername>"
+            value: "gcr-events-<cluster name>"
+          - name: FLUX_EVENTS_PUBSUB_GOOGLE_PUBSUB_TOPIC_GCR
+            value: "gcr-events"
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: "/secrets/pubsub-credentials"
           - name: FLUX_EVENTS_PUBSUB_GOOGLE_PROJECT

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ var (
 	googleProject            = command.Flag("google-project", "Google project").Required().String()
 	googleProjectGcrLocation = command.Flag("google-project-gcr", "Google project were gcr is located").Required().String()
 	pubsubSubscriptionGcr    = command.Flag("google-pubsub-subscription-gcr", "Google pubsub subscription for gcr").Default("gcr").String()
+	pubsubTopicGcr           = command.Flag("google-pubsub-topic-gcr", "Google pubsub topic for gcr").Default("gcr").String()
 	pubsubTopicEvents        = command.Flag("google-pubsub-topic", "Google pubsub topic for events").Required().String()
 	pubsubTopicActions       = command.Flag("google-pubsub-topic-actions", "Google pubsub topic for actions").Required().String()
 	pubsubSubscription       = command.Flag("google-pubsub-subscription", "Google pubsub subscription").Required().String()
@@ -64,7 +65,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 
-	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, "gcr", *pubsubSubscriptionGcr)
+	gcrSubscriber, err := pkg.NewGCRSubscriber(ctx, *googleProjectGcrLocation, *pubsubTopicGcr, *pubsubSubscriptionGcr)
 	if err != nil {
 		log.Errorf("pubsub.NewGCRSubscriber: %v", err)
 		return nil, err


### PR DESCRIPTION
adding option to pass flag `--google-pubsub-topic-gcr` to allow different topic names for gcr image events defaults to `gcr`